### PR TITLE
Concurrency fix

### DIFF
--- a/framework/org.eclipse.concierge/src/org/eclipse/concierge/Concierge.java
+++ b/framework/org.eclipse.concierge/src/org/eclipse/concierge/Concierge.java
@@ -3857,7 +3857,8 @@ public final class Concierge extends AbstractBundle implements Framework,
 			// prepare the data structures
 			final MultiMap<BundleContext, ListenerInfo> mmap = new MultiMap<BundleContext, ListenerInfo>();
 
-			for (final Iterator<ServiceListenerEntry> iter = serviceListeners
+			final List<ServiceListenerEntry> serviceListenersCopy = new ArrayList<Concierge.ServiceListenerEntry>(serviceListeners);
+			for (final Iterator<ServiceListenerEntry> iter = serviceListenersCopy
 					.iterator(); iter.hasNext();) {
 				final ServiceListenerEntry entry = iter.next();
 				mmap.insert(entry.bundle.context, entry);
@@ -3906,8 +3907,6 @@ public final class Concierge extends AbstractBundle implements Framework,
 			}
 
 			final ArrayList<ServiceListenerEntry> list = new ArrayList<ServiceListenerEntry>();
-			final ArrayList<ServiceListenerEntry> serviceListenersCopy 
-				= new ArrayList<ServiceListenerEntry>(serviceListeners);
 			for (final Iterator<ServiceListenerEntry> iter = serviceListenersCopy
 					.iterator(); iter.hasNext();) {
 				final ServiceListenerEntry entry = iter.next();

--- a/framework/org.eclipse.concierge/src/org/eclipse/concierge/ServiceReferenceImpl.java
+++ b/framework/org.eclipse.concierge/src/org/eclipse/concierge/ServiceReferenceImpl.java
@@ -483,36 +483,40 @@ final class ServiceReferenceImpl<S> implements ServiceReference<S> {
 						"Service has already been uninstalled");
 			}
 
-			final Map<String, Object> oldProps = new HashMap<String, Object>(
-					properties);
-
-			final HashMap<String, String> cases = new HashMap<String, String>(
-					properties.size());
-			for (final String key : properties.keySet()) {
-				final String lower = key.toLowerCase();
-				if (cases.containsKey(lower)) {
-					throw new IllegalArgumentException(
-							"Properties contain the same key in different case variants");
-				}
-				cases.put(lower, key);
-			}
-			for (final Enumeration<String> keys = newProps.keys(); keys
-					.hasMoreElements();) {
-				final String key = keys.nextElement();
-				final Object value = newProps.get(key);
-				final String lower = key.toLowerCase();
-
-				if (!forbidden.contains(lower)) {
-					final Object existing = cases.get(lower);
-					if (existing != null) {
-						if (existing.equals(key)) {
-							properties.remove(existing);
-						} else {
-							throw new IllegalArgumentException(
-									"Properties already exists in a different case variant");
-						}
+			final Map<String, Object> oldProps;
+			// could be called from multiple threads
+			synchronized(properties){
+				oldProps = new HashMap<String, Object>(
+						properties);
+	
+				final HashMap<String, String> cases = new HashMap<String, String>(
+						properties.size());
+				for (final String key : properties.keySet()) {
+					final String lower = key.toLowerCase();
+					if (cases.containsKey(lower)) {
+						throw new IllegalArgumentException(
+								"Properties contain the same key in different case variants");
 					}
-					properties.put(key, value);
+					cases.put(lower, key);
+				}
+				for (final Enumeration<String> keys = newProps.keys(); keys
+						.hasMoreElements();) {
+					final String key = keys.nextElement();
+					final Object value = newProps.get(key);
+					final String lower = key.toLowerCase();
+	
+					if (!forbidden.contains(lower)) {
+						final Object existing = cases.get(lower);
+						if (existing != null) {
+							if (existing.equals(key)) {
+								properties.remove(existing);
+							} else {
+								throw new IllegalArgumentException(
+										"Properties already exists in a different case variant");
+							}
+						}
+						properties.put(key, value);
+					}
 				}
 			}
 


### PR DESCRIPTION
Two fixes regarding potential concurrency issues:
* we take copies of the service listeners arrays, but at one point this was omitted/forgotten - fixed that
* properties of a service can be set by multiple threads simultaneously ... add synchronized block around the change