### PR TITLE
Fixed wrong test case adding optional ("*") to Bundle-NativeCode header #34

### DIFF
--- a/framework/org.eclipse.concierge/test/org/eclipse/concierge/BundlesWithNativeCodeTest.java
+++ b/framework/org.eclipse.concierge/test/org/eclipse/concierge/BundlesWithNativeCodeTest.java
@@ -105,7 +105,7 @@ public class BundlesWithNativeCodeTest extends AbstractConciergeTestCase {
 				.newBuilder();
 		builder.bundleSymbolicName("testBundleNativeCodeWithWildcard")
 				.bundleVersion("1.0.0").addManifestHeader("Bundle-NativeCode",
-						"lib/native/someNative.so; osname=MacOSX; processor=x86; *");
+						"lib/native/someNative.so; osname=MacOSX; processor=x86, *");
 		final Bundle bundleUnderTest = installBundle(builder);
 		enforceResolveBundle(bundleUnderTest);
 		final boolean resolved = isBundleResolved(bundleUnderTest);


### PR DESCRIPTION
Signed-off-by: Jochen Hiller <j.hiller@telekom.de>