### PR TITLE
Fix NPE when checking compact profiles on CEE-J (#39)

### DIFF
--- a/framework/org.eclipse.concierge/src/org/eclipse/concierge/Concierge.java
+++ b/framework/org.eclipse.concierge/src/org/eclipse/concierge/Concierge.java
@@ -676,7 +676,6 @@ public final class Concierge extends AbstractBundle implements Framework,
 
 		
 
-
 		if (System.getProperty("java.specification.name")
 				.equals("J2ME Foundation Specification")) {
 			switch (minor) {
@@ -693,16 +692,23 @@ public final class Concierge extends AbstractBundle implements Framework,
 				// also add the valid compact profiles
 				try {
 					// Figure out the profile by loading some classes from the profile
-					// Is there any other way to discover the profile of the JRE?
+					// we do NOT use the $JAVA_HOME/release file like this is done by Equinox
+					// this would NOT be portable across different JVMs
 					myEEs.append("JavaSE-1.8/compact1,");
 					compact1VersionList.append("1.8,");
-				 	this.getClass().getClassLoader().loadClass("org.w3c.dom.Document");
+					
+					// we try to load the class from our own class loader without initializing the class
+					// be careful to not use this.getClass().getClassLoader().loadClass("...")
+					// as some JVM, e.g. CEE-J will return null as class loader when
+					// the framework has been loaded by the bootstrap class loader
+					// Class.forName("name", false, classLoader) can handle the case when class loader is null
+					Class.forName("org.w3c.dom.Document", false, this.getClass().getClassLoader());
 				 	myEEs.append("JavaSE-1.8/compact2,");
 				 	compact2VersionList.append("1.8,");
-				 	this.getClass().getClassLoader().loadClass("javax.management.Descriptor");
+				 	Class.forName("javax.management.Descriptor", false, this.getClass().getClassLoader());
 				 	myEEs.append("JavaSE-1.8/compact3,");
 				 	compact3VersionList.append("1.8,");
-					this.getClass().getClassLoader().loadClass("javax.imageio.ImageIO");
+				 	Class.forName("javax.imageio.ImageIO", false, this.getClass().getClassLoader());
 				} catch(ClassNotFoundException e){
 				}
 				seVersionList.append("1.8,");

--- a/framework/org.eclipse.concierge/test/org/eclipse/concierge/ConciergeJavaSE8ExecutionEnvironmentTest.java
+++ b/framework/org.eclipse.concierge/test/org/eclipse/concierge/ConciergeJavaSE8ExecutionEnvironmentTest.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ * Copyright (c) 2014 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Jochen Hiller
+ *******************************************************************************/
+package org.eclipse.concierge;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.concierge.test.util.AbstractConciergeTestCase;
+import org.eclipse.concierge.test.util.FilteredClassLoader;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * This class tests in JavaSE 8 the Execution Environments, especially the
+ * support of the JavaSE8 compact profiles.
+ * 
+ * To test if the compact profiles will be handled correct, the framework will
+ * be started in an own class loader, which allows to "mock" the existence of
+ * some classes. This allows to "fake" the discovery of compact profiles even if
+ * running on a full JavaSE 8 installation.
+ * 
+ * If this test does NOT run with JavaSE 8, it will skip it tests, and report a
+ * warning.
+ */
+public class ConciergeJavaSE8ExecutionEnvironmentTest
+		extends AbstractConciergeTestCase {
+
+	@Test
+	public void testConciergeJavaSE8Compact1() throws Exception {
+		if (!checkForJavaSE8("testConciergeJavaSE8Compact1")) {
+			return;
+		}
+		ClassLoader cl = new FilteredClassLoader(
+				this.getClass().getClassLoader(), "org.w3c.dom.Document");
+		String eeCaps = startFrameworkInClassLoaderAndReturnEECapabilities(cl);
+		Assert.assertTrue(eeCaps.contains(
+				"JavaSE, version=[1.8.0, 1.7.0, 1.6.0, 1.5.0, 1.4.0, 1.3.0, 1.2.0, 1.1.0]"));
+		Assert.assertTrue(eeCaps.contains("JavaSE/compact1, version=[1.8.0]"));
+		Assert.assertFalse(eeCaps.contains("JavaSE/compact2, version=[1.8.0]"));
+		Assert.assertFalse(eeCaps.contains("JavaSE/compact3, version=[1.8.0]"));
+	}
+
+	@Test
+	public void testConciergeJavaSE8Compact2() throws Exception {
+		if (!checkForJavaSE8("testConciergeJavaSE8Compact2")) {
+			return;
+		}
+		ClassLoader cl = new FilteredClassLoader(
+				this.getClass().getClassLoader(),
+				"javax.management.Descriptor");
+		String eeCaps = startFrameworkInClassLoaderAndReturnEECapabilities(cl);
+		Assert.assertTrue(eeCaps.contains(
+				"JavaSE, version=[1.8.0, 1.7.0, 1.6.0, 1.5.0, 1.4.0, 1.3.0, 1.2.0, 1.1.0]"));
+		Assert.assertTrue(eeCaps.contains("JavaSE/compact1, version=[1.8.0]"));
+		Assert.assertTrue(eeCaps.contains("JavaSE/compact2, version=[1.8.0]"));
+		Assert.assertFalse(eeCaps.contains("JavaSE/compact3, version=[1.8.0]"));
+	}
+
+	@Test
+	public void testConciergeJavaSE8Compact3() throws Exception {
+		if (!checkForJavaSE8("testConciergeJavaSE8Compact3")) {
+			return;
+		}
+		ClassLoader cl = new FilteredClassLoader(
+				this.getClass().getClassLoader(), "javax.imageio.ImageIO");
+		String eeCaps = startFrameworkInClassLoaderAndReturnEECapabilities(cl);
+		Assert.assertTrue(eeCaps.contains(
+				"JavaSE, version=[1.8.0, 1.7.0, 1.6.0, 1.5.0, 1.4.0, 1.3.0, 1.2.0, 1.1.0]"));
+		Assert.assertTrue(eeCaps.contains("JavaSE/compact1, version=[1.8.0]"));
+		Assert.assertTrue(eeCaps.contains("JavaSE/compact2, version=[1.8.0]"));
+		Assert.assertTrue(eeCaps.contains("JavaSE/compact3, version=[1.8.0]"));
+	}
+
+	@Test
+	public void testStartConciergeWithFullJRE() throws Exception {
+		if (!checkForJavaSE8("testStartConciergeWithFullJRE")) {
+			return;
+		}
+		ClassLoader cl = new FilteredClassLoader(
+				this.getClass().getClassLoader()); // no filter
+		String eeCaps = startFrameworkInClassLoaderAndReturnEECapabilities(cl);
+		Assert.assertTrue(eeCaps.contains(
+				"JavaSE, version=[1.8.0, 1.7.0, 1.6.0, 1.5.0, 1.4.0, 1.3.0, 1.2.0, 1.1.0]"));
+		Assert.assertTrue(eeCaps.contains("JavaSE/compact1, version=[1.8.0]"));
+		Assert.assertTrue(eeCaps.contains("JavaSE/compact2, version=[1.8.0]"));
+		Assert.assertTrue(eeCaps.contains("JavaSE/compact3, version=[1.8.0]"));
+	}
+
+	// helper methods
+
+	private boolean checkForJavaSE8(String testName) {
+		String javaVersion = System.getProperty("java.specification.version");
+		boolean isJavaSE8 = "1.8".equals(javaVersion);
+		if (!isJavaSE8) {
+			System.err.println("Will skip the test '" + testName
+					+ "' as not running in JavaSE 8, but in Java " + javaVersion
+					+ " instead");
+		}
+		return isJavaSE8;
+	}
+
+	/**
+	 * This method will start a Concierge framework in a given ClassLoader. This
+	 * will all be done via reflection to avoid any references in test code
+	 * here. It will return the execution environment capabilities as a String
+	 * for further tests.
+	 */
+	private String startFrameworkInClassLoaderAndReturnEECapabilities(
+			ClassLoader cl) throws Exception {
+		RunInClassLoader runner = new AbstractConciergeTestCase.RunInClassLoader(
+				cl);
+
+		// Framework framework = new Concierge(emptyMap);
+		Map<String, String> launchArgs = new HashMap<String, String>();
+		Object framework = runner.createInstance(
+				"org.eclipse.concierge.Concierge",
+				new String[] { Map.class.getName() },
+				new Object[] { launchArgs });
+		try {
+			// framework.init();
+			runner.callMethodNoArgs(framework, "init");
+			// framework.start();
+			runner.callMethodNoArgs(framework, "start");
+			// BundleWiring w = framework.adapt(BundleWiring.class);
+			Object w = runner.callMethod(framework, "adapt",
+					new Object[] { Class.forName(
+							"org.osgi.framework.wiring.BundleWiring", false,
+							cl) });
+			// List<BundleCapability> caps = w.getCapabilities("osgi.ee");
+			Object caps = runner.callMethod(w, "getCapabilities",
+					new Object[] { "osgi.ee" });
+
+			return caps.toString();
+		} finally {
+			// framework.stop();
+			runner.callMethodNoArgs(framework, "stop");
+		}
+	}
+
+}

--- a/framework/org.eclipse.concierge/test/org/eclipse/concierge/test/util/AbstractConciergeTestCase.java
+++ b/framework/org.eclipse.concierge/test/org/eclipse/concierge/test/util/AbstractConciergeTestCase.java
@@ -419,7 +419,7 @@ public abstract class AbstractConciergeTestCase {
 		 * Get a class references based on bundle classloader.
 		 */
 		public Class<?> getClass(final String className) throws Exception {
-			final Class<?> clazz = this.classLoader.loadClass(className);
+			final Class<?> clazz = this.bundle.loadClass(className);
 			return clazz;
 		}
 

--- a/framework/org.eclipse.concierge/test/org/eclipse/concierge/test/util/AbstractConciergeTestCase.java
+++ b/framework/org.eclipse.concierge/test/org/eclipse/concierge/test/util/AbstractConciergeTestCase.java
@@ -398,10 +398,17 @@ public abstract class AbstractConciergeTestCase {
 	public static class RunInClassLoader {
 
 		private final Bundle bundle;
+		private final ClassLoader classLoader;
 		private boolean debug = false;
 
 		public RunInClassLoader(Bundle b) {
 			this.bundle = b;
+			this.classLoader = b.getClass().getClassLoader();
+		}
+
+		public RunInClassLoader(ClassLoader cl) {
+			this.bundle = null;
+			this.classLoader = cl;
 		}
 
 		public void debug(boolean debug) {
@@ -412,7 +419,7 @@ public abstract class AbstractConciergeTestCase {
 		 * Get a class references based on bundle classloader.
 		 */
 		public Class<?> getClass(final String className) throws Exception {
-			final Class<?> clazz = this.bundle.loadClass(className);
+			final Class<?> clazz = this.classLoader.loadClass(className);
 			return clazz;
 		}
 
@@ -426,7 +433,7 @@ public abstract class AbstractConciergeTestCase {
 
 		public Object getClassField(final String className,
 				final String classFieldName) throws Exception {
-			final Class<?> clazz = this.bundle.loadClass(className);
+			final Class<?> clazz = this.classLoader.loadClass(className);
 			final Field field = clazz.getField(classFieldName);
 			if (!Modifier.isStatic(field.getModifiers())) {
 				throw new RuntimeException(
@@ -443,8 +450,8 @@ public abstract class AbstractConciergeTestCase {
 		 */
 		public Object callClassMethod(final String className,
 				final String classMethodName, final Object[] args)
-						throws Exception {
-			final Class<?> clazz = this.bundle.loadClass(className);
+				throws Exception {
+			final Class<?> clazz = this.classLoader.loadClass(className);
 			// get parameter types from args
 			final Class<?>[] parameterTypes = new Class[args.length];
 			for (int i = 0; i < args.length; i++) {
@@ -463,7 +470,7 @@ public abstract class AbstractConciergeTestCase {
 
 		public Object createInstance(String className, final Object[] args)
 				throws Exception {
-			final Class<?> clazz = this.bundle.loadClass(className);
+			final Class<?> clazz = this.classLoader.loadClass(className);
 			dumpDeclaredConstructors(clazz);
 			// get parameter types from args
 			final Class<?>[] parameterTypes = new Class[args.length];
@@ -483,20 +490,31 @@ public abstract class AbstractConciergeTestCase {
 
 		public Object createInstance(String className,
 				final String[] parameterTypeNames, final Object[] args)
-						throws Exception {
-			final Class<?> clazz = this.bundle.loadClass(className);
+				throws Exception {
+			final Class<?> clazz = this.classLoader.loadClass(className);
 			dumpDeclaredConstructors(clazz);
 			// get parameter types from args
 			final Class<?>[] parameterTypes = new Class[args.length];
 			for (int i = 0; i < parameterTypeNames.length; i++) {
-				parameterTypes[i] = bundle.getClass().getClassLoader()
+				parameterTypes[i] = this.classLoader.getClass().getClassLoader()
 						.loadClass(parameterTypeNames[i]);
 			}
 			final Constructor<?> constructor = clazz
 					.getDeclaredConstructor(parameterTypes);
-			// TODO jhi Maybe set accessible if private?
+			if (!constructor.isAccessible()) {
+				constructor.setAccessible(true);
+			}
 			final Object result = constructor.newInstance(args);
 			return result;
+		}
+
+		/**
+		 * Call an instance method of a method without arguments for given
+		 * object.
+		 */
+		public Object callMethodNoArgs(final Object obj,
+				final String methodName) throws Exception {
+			return callMethod(obj, methodName, new Object[] {});
 		}
 
 		/**
@@ -521,6 +539,9 @@ public abstract class AbstractConciergeTestCase {
 				throw new RuntimeException(
 						"Oops, method " + method.toString() + " is static");
 			}
+			if (!method.isAccessible()) {
+				method.setAccessible(true);
+			}
 			final Object result = method.invoke(obj, args);
 			return result;
 		}
@@ -533,7 +554,7 @@ public abstract class AbstractConciergeTestCase {
 		 */
 		public Object callMethod(final Object obj, final String methodName,
 				final Class<?>[] parameterTypes, final Object[] args)
-						throws Exception {
+				throws Exception {
 			final Class<?> clazz = obj.getClass();
 			dumpMethods(clazz);
 			dumpDeclaredMethods(clazz);

--- a/framework/org.eclipse.concierge/test/org/eclipse/concierge/test/util/FilteredClassLoader.java
+++ b/framework/org.eclipse.concierge/test/org/eclipse/concierge/test/util/FilteredClassLoader.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2014 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Jochen Hiller
+ *******************************************************************************/
+package org.eclipse.concierge.test.util;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * This class is a ClassLoader which allows to filter loading of specific
+ * classes.
+ * 
+ * E.g. we can mock different compact profiles by hiding the files used for
+ * identification of compact profile.
+ * 
+ * The "filter" can be an expression like:
+ * <ul>
+ * <li>org.w3c.dom.Document</li>
+ * <li>org.w3c.dom.*</li>
+ * </ul>
+ * 
+ * @author Jochen Hiller
+ */
+public class FilteredClassLoader extends ClassLoader {
+
+	/** Is protected to give potential subclasses access to this field. */
+	protected final String filterExpression;
+
+	public FilteredClassLoader(ClassLoader parent) {
+		super(parent);
+		this.filterExpression = null; // mark: we do NOT have a filter
+	}
+
+	public FilteredClassLoader(ClassLoader parent, String expr) {
+		super(parent);
+		this.filterExpression = expr;
+	}
+
+	/**
+	 * This method might be overridden by subclasses to handle special cases.
+	 */
+	public boolean isFiltered(String className) {
+		if (filterExpression != null) {
+			if (filterExpression.endsWith(".*")) {
+				// include trailing dot in pkgName
+				String pkgName = filterExpression.substring(0,
+						filterExpression.lastIndexOf(".*") + 1);
+				if (className.startsWith(pkgName)) {
+					return true;
+				} else {
+					return false;
+				}
+			} else {
+				if ((className.startsWith(filterExpression))) {
+					return true;
+				} else {
+					return false;
+				}
+			}
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public Class<?> loadClass(String name) throws ClassNotFoundException {
+		logInfo("loading class '" + name + "'");
+		// load java.* classes always from parent class loader
+		if (name.startsWith("java.")) {
+			return super.loadClass(name);
+		}
+		// if class is filtered, throw a ClassNotFoundException
+		if (isFiltered(name)) {
+			String msg = "Could not find the class '" + name
+					+ "' due to filter '" + filterExpression + "'";
+			logError(msg);
+			throw new ClassNotFoundException(msg);
+		}
+		// otherwise load class themselves
+		return loadAndDefineClass(name);
+	}
+
+	/**
+	 * Load and create a class internally if found.
+	 */
+	private Class<?> loadAndDefineClass(String classNameWithDots)
+			throws ClassNotFoundException {
+		String classNameAsFileName = classNameWithDots.replace('.',
+				File.separatorChar) + ".class";
+		try {
+			byte[] classByteCodeBuffer = loadClassByteCode(classNameAsFileName);
+			// define and resolve the class
+			Class<?> clazz = defineClass(classNameWithDots, classByteCodeBuffer,
+					0, classByteCodeBuffer.length);
+			resolveClass(clazz);
+			return clazz;
+		} catch (IOException ex) {
+			ex.printStackTrace();
+			return null;
+		}
+	}
+
+	/**
+	 * Loads the byte code for class specified by name into a byte array buffer.
+	 */
+	private byte[] loadClassByteCode(String classNameAsFileName)
+			throws IOException {
+		InputStream inputStream = getClass().getClassLoader()
+				.getResourceAsStream(classNameAsFileName);
+		int size = inputStream.available();
+		byte buffer[] = new byte[size];
+		DataInputStream dataInputStream = new DataInputStream(inputStream);
+		dataInputStream.readFully(buffer);
+		dataInputStream.close();
+		return buffer;
+	}
+
+	private void logInfo(String msg) {
+		// enable to trace class loading
+		// System.out.println("[FilteredClassLoader] " + msg);
+	}
+
+	private void logError(String msg) {
+		// enable to trace class loading
+		// System.err.println("[FilteredClassLoader] " + msg);
+	}
+}

--- a/framework/org.eclipse.concierge/test/org/eclipse/concierge/test/util/FilteredClassLoaderTest.java
+++ b/framework/org.eclipse.concierge/test/org/eclipse/concierge/test/util/FilteredClassLoaderTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2014 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *     Jochen Hiller
+ *******************************************************************************/
+package org.eclipse.concierge.test.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test of the FilteredClassLoader, if filtered classes will really be denied.
+ */
+public class FilteredClassLoaderTest extends AbstractConciergeTestCase {
+
+	@Test
+	public void testFilterFullClassName() throws Exception {
+		ClassLoader cl = new FilteredClassLoader(
+				this.getClass().getClassLoader(), "org.w3c.dom.Document");
+		// this class needs to be found
+		Class<?> clsFound = Class.forName("java.lang.Object", false, cl);
+		Assert.assertNotNull(clsFound);
+		try {
+			// this class should throw a CNF Exception, due to filtering
+			Class.forName("org.w3c.dom.Document", false, cl);
+			Assert.fail("Uups, ClassNotFoundException expected");
+		} catch (ClassNotFoundException expected) {
+			// CNF exception expected
+		}
+	}
+
+	@Test
+	public void testFilterPackageNameWithStarAtEnd() throws Exception {
+		ClassLoader cl = new FilteredClassLoader(
+				this.getClass().getClassLoader(), "org.w3c.dom.*");
+		// this class needs to be found
+		Class<?> clsFound = Class.forName("java.lang.Object", false, cl);
+		Assert.assertNotNull(clsFound);
+		try {
+			// this class should throw a CNF Exception, due to filtering
+			Class.forName("org.w3c.dom.Document", false, cl);
+			Assert.fail("Uups, ClassNotFoundException expected");
+		} catch (ClassNotFoundException expected) {
+			// CNF exception expected
+		}
+	}
+
+	@Test
+	public void testFilterPackageNameWithStarTopLevel() throws Exception {
+		ClassLoader cl = new FilteredClassLoader(
+				this.getClass().getClassLoader(), "org.*");
+		// this class needs to be found
+		Class<?> clsFound = Class.forName("java.lang.Object", false, cl);
+		Assert.assertNotNull(clsFound);
+		try {
+			// this class should throw a CNF Exception, due to filtering
+			Class.forName("org.w3c.dom.Document", false, cl);
+			Assert.fail("Uups, ClassNotFoundException expected");
+		} catch (ClassNotFoundException expected) {
+			// CNF exception expected
+		}
+	}
+}


### PR DESCRIPTION
* Added test cases for JavaSE 8 and compact profiles
* changed check for classes of compact profile to use Class.forName() now
* added helper classes for extended testing (FilteredClassLoader)
* extended RunInClassLoader for simpler use with ClassLoaders too
