### PR TITLE
Fixed native library support according to failed TCK tests (#45)

### DIFF
--- a/framework/org.eclipse.concierge/src/org/eclipse/concierge/BundleImpl.java
+++ b/framework/org.eclipse.concierge/src/org/eclipse/concierge/BundleImpl.java
@@ -2010,7 +2010,9 @@ public class BundleImpl extends AbstractBundle implements BundleStartLevel {
 						if (a > -1) {
 							final String criterium = token.substring(0, a)
 									.trim().intern();
-							final String value = token.substring(a + 1).trim();
+							// trim and remove all double quotes,
+							// like in osname "mac os x" where quotes are part of string
+							final String value = token.substring(a + 1).trim().replace("\"", "");;
 							if (criterium == Constants.BUNDLE_NATIVECODE_OSNAME) {
 								if (framework.osname.startsWith("Windows")) {
 									n |= value.toLowerCase().startsWith("win");

--- a/framework/org.eclipse.concierge/src/org/eclipse/concierge/Concierge.java
+++ b/framework/org.eclipse.concierge/src/org/eclipse/concierge/Concierge.java
@@ -1173,8 +1173,14 @@ public final class Concierge extends AbstractBundle implements Framework,
 		}
 
 		// get the library extensions if set
-		final String libExtStr = properties
+		String libExtStr = properties
 				.getProperty(Constants.FRAMEWORK_LIBRARY_EXTENSIONS);
+		// set some platform defaults it not set
+		if (libExtStr == null) {
+			if (osname.startsWith("MacOS")) {
+				libExtStr = "dylib,jnilib";
+			}
+		}
 		if (libExtStr != null) {
 			libraryExtensions = Utils.splitString(libExtStr, ',');
 		}
@@ -5168,7 +5174,10 @@ public final class Concierge extends AbstractBundle implements Framework,
 		final String[] result = new String[libraryExtensions.length + 1];
 		result[0] = System.mapLibraryName(libname);
 		for (int i = 0; i < libraryExtensions.length; i++) {
-			result[i + 1] = libname + "." + libraryExtensions[i];
+			// we will use the default name and replace the extension of that
+			// e.g. on Mac the lib name for "XYZ" is "libXYZ.dylib" which will be 
+			// added here to "libXYZ.jnilib"
+			result[i + 1] = result[0].substring(0, result[0].lastIndexOf(".") + 1)+ libraryExtensions[i];
 		}
 		return result;
 	}


### PR DESCRIPTION
* use platform defaults for FRAMEWORK_LIBRARY_EXTENSIONS on MacOS*
* fix parsing when osname contains quotes (e.g. for osname aliases)
* fix building native library name when using configured library extensions

Signed-off-by: Jochen Hiller <j.hiller@telekom.de>